### PR TITLE
fix(actions): Update upload-artifact to v4 in workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./gradlew :app:clean :app:assembleRelease
 
       - name: Upload Build Artifact (APK)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4 # <<< This line needs to change
         with:
           name: apk
           path: app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
The GitHub Actions workflow was failing due to an issue with `actions/upload-artifact@v3` ("Error: Missing download info").

This commit updates the "Upload Build Artifact (APK)" step in `.github/workflows/android-build.yml` to use `actions/upload-artifact@v4`.

This should resolve the download issue and allow the workflow to complete successfully.